### PR TITLE
Remove the GNU date command dependency

### DIFF
--- a/network.sh
+++ b/network.sh
@@ -606,7 +606,7 @@ function clean() {
 }
 
 function generateWait() {
-  echo "$(date --rfc-3339='seconds' -u) *** Wait for 7 minutes to make sure the certificates become active ***"
+  echo "$(date -u "+%Y-%m-%d %T %Z") *** Wait for 7 minutes to make sure the certificates become active ***"
   sleep 7m
 }
 


### PR DESCRIPTION
The RFC standard is available only in the GNU version of date
command. This does not for example work on OS X. Changing
the output to old school method will work on OS X as well.

Signed-off-by: S m, Aruna <aruna.mohan@walmartlabs.com>